### PR TITLE
Fix non-local return issue

### DIFF
--- a/mc/Voyage-Mongo-Core.package/VOMongoReadOneOperation.class/instance/basicSelectOne.st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoReadOneOperation.class/instance/basicSelectOne.st
@@ -3,11 +3,4 @@ basicSelectOne
 	Mongo debugLog: 'readOne'.
 	self repository
 		collectionAt: queryClass
-		readingDo: [ :collection |
-			(collection
-				commandFind: where asMongoQuery
-				limit: 0
-				readConcern: nil)
-				setFlagSlaveOk;
-				do: [ :found | ^ found ].
-			^ nil ]
+		readingDo: [ :collection | collection detect: where ]

--- a/mc/Voyage-Mongo-Core.package/VOMongoReadOneOperation.class/instance/basicSelectOne.st
+++ b/mc/Voyage-Mongo-Core.package/VOMongoReadOneOperation.class/instance/basicSelectOne.st
@@ -1,6 +1,6 @@
 persistence
 basicSelectOne
 	Mongo debugLog: 'readOne'.
-	self repository
+	^ self repository
 		collectionAt: queryClass
 		readingDo: [ :collection | collection detect: where ]


### PR DESCRIPTION
Revert block implementation back to using simple detect: where statement. Fixes issue #164 with Mongo connections not being returned to the pool.